### PR TITLE
Skaffold v2fix

### DIFF
--- a/cloudrun/queue/skaffold.yaml
+++ b/cloudrun/queue/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: queue
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8000
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/adp_ui/skaffold.yaml
+++ b/microservices/adp_ui/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta26
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: adp-ui
@@ -23,12 +23,16 @@ build:
     docker:
       dockerfile: Dockerfile
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/dev
 profiles:
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -49,6 +53,8 @@ profiles:
       docker:
         dockerfile: Dockerfile-dev
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/classification_service/skaffold.yaml
+++ b/microservices/classification_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: classification-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8890
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/document_status_service/skaffold.yaml
+++ b/microservices/document_status_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: document-status-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8894
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/extraction_service/skaffold.yaml
+++ b/microservices/extraction_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: extraction-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8892
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/hitl_service/skaffold.yaml
+++ b/microservices/hitl_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: hitl-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8893
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/matching_service/skaffold.yaml
+++ b/microservices/matching_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: matching-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8895
 deploy:
+  kubectl: {}
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: {}
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: {}
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: {}
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: {}
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/sample_service/skaffold.yaml
+++ b/microservices/sample_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: sample-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8888
 deploy:
+  kubectl: {}
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/upload_service/skaffold.yaml
+++ b/microservices/upload_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: upload-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8889
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev

--- a/microservices/validation_service/skaffold.yaml
+++ b/microservices/validation_service/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: validation-service
@@ -39,6 +39,8 @@ portForward:
   port: 80
   localPort: 8891
 deploy:
+  kubectl: { }
+manifests:
   kustomize:
     paths:
     - ./kustomize/minikube
@@ -52,16 +54,22 @@ profiles:
       - image: common
         alias: BASE_IMG
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/custom
 - name: prod_non_cloudbuild
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
 - name: prod
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/prod
@@ -93,6 +101,8 @@ profiles:
           - '**/*.py'
           - '**/*.json'
   deploy:
+    kubectl: { }
+  manifests:
     kustomize:
       paths:
       - ./kustomize/dev


### PR DESCRIPTION
Fix to skaffold.yaml files to support skaffold v2 deployment step (along with apiVersion schema version v3)
Without this change, skaffold v2 would not deploy on the command skaffold run, only do the build step.
See https://skaffold.dev/docs/upgrading/ for more details